### PR TITLE
feat: add /speakers endpoint and support dynamic narrators/emotions (vpeak v0.3.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vpeakserver
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -79,15 +79,19 @@ go install github.com/shinshin86/vpeakserver@latest
 ## Endpoint
 This repository provides a simple HTTP server for handling audio synthesis requests and a VOICEPEAK user dictionary API. It exposes the following endpoints:
 
-1. `/audio_query`: Accepts a POST request with query parameters to return a JSON-encoded `AudioQuery`.
-2. `/synthesis`: Accepts a POST request with a JSON body that generates and returns an audio file (`.wav`) synthesized using the specified text and speaker.
-3. `/user_dict`: Returns the registered VOICEPEAK user dictionary as a JSON array.
-4. `/user_dict_word`: Adds a user dictionary word.
-5. `/user_dict_word/by-surface/{surface}`: Updates or deletes a user dictionary word by its current `surface`.
-6. `/import_user_dict`: Imports a VOICEPEAK-native dictionary JSON array.
-7. `/setting`: Provides a web interface for configuring CORS settings.
+1. `/speakers`: Accepts a GET request and returns the narrator names installed in the local VOICEPEAK as a JSON array.
+2. `/audio_query`: Accepts a POST request with query parameters to return a JSON-encoded `AudioQuery`.
+3. `/synthesis`: Accepts a POST request with a JSON body that generates and returns an audio file (`.wav`) synthesized using the specified text and speaker.
+4. `/user_dict`: Returns the registered VOICEPEAK user dictionary as a JSON array.
+5. `/user_dict_word`: Adds a user dictionary word.
+6. `/user_dict_word/by-surface/{surface}`: Updates or deletes a user dictionary word by its current `surface`.
+7. `/import_user_dict`: Imports a VOICEPEAK-native dictionary JSON array.
+8. `/setting`: Provides a web interface for configuring CORS settings.
 
 ## Features
+- **Speakers Endpoint**:  
+  Sends a GET request to `/speakers` to retrieve the narrators installed in the local VOICEPEAK as a JSON array (e.g. `["Japanese Female 1", "Zundamon"]`). The list is queried live from VOICEPEAK, so any installed narrator — including character products and add-on narrators — is returned without code changes.
+
 - **Audio Query Endpoint**:  
   Sends a POST request to `/audio_query` with `text` and `speaker` as required query parameters. Optional `emotion`, `speed`, and `pitch` parameters let you mirror the synthesis request and validate them before submission.
 
@@ -98,7 +102,8 @@ This repository provides a simple HTTP server for handling audio synthesis reque
   Adds a VOICEPEAK-native user dictionary API. The server updates VOICEPEAK's actual `dic.json` through [vpeak](https://github.com/shinshin86/vpeak); it does not maintain a separate preprocessing dictionary.
 
 - **Voice Parameter Control**:  
-  - `emotion`: Supports `happy`, `fun`, `angry`, `sad` with optional `0`-`100` weights. Examples: `happy`, `happy=50`, `happy=40,fun=60`. Invalid values return `400 Bad Request`.  
+  - `speaker`: Any narrator installed in the local VOICEPEAK can be specified by the name reported by `/speakers` (e.g. `Zundamon`). The short aliases `f1`–`m3` and `c` are still accepted as input.
+  - `emotion`: Emotion names depend on the selected narrator (e.g. `happy`, `fun`, or character-specific emotions such as `amaama`). Optional `0`-`100` weights, comma-separated for multiple, and a bare name is equivalent to `=100`. Examples: `happy`, `happy=50`, `happy=40,fun=60`. The server validates the syntax (a malformed weight returns `400 Bad Request`); whether an emotion name is supported is determined by VOICEPEAK.  
   - `speed`: Integer in the range `50`–`200`.  
   - `pitch`: Integer in the range `-300`–`300`.
 

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.23.2
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/shinshin86/vpeak v0.2.0
+	github.com/shinshin86/vpeak v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/shinshin86/vpeak v0.2.0 h1:uF122dPRdcXy9LdP8n85b9MPCoYfEoYvYEkCMqKFERQ=
-github.com/shinshin86/vpeak v0.2.0/go.mod h1:yYLDKkGnHWJyaDTpj3tByMlEng8mfO73O5U3WsqB9LY=
+github.com/shinshin86/vpeak v0.3.0 h1:mbEiiayT8Kp0jWhs0HYkP6/W+3rSsgmSYkFIfMVx9IM=
+github.com/shinshin86/vpeak v0.3.0/go.mod h1:yYLDKkGnHWJyaDTpj3tByMlEng8mfO73O5U3WsqB9LY=

--- a/server.go
+++ b/server.go
@@ -46,6 +46,7 @@ type Server struct {
 	mux             *http.ServeMux
 	logger          *log.Logger
 	speechGenerator func(text string, opts vpeak.Options) error
+	narratorLister  func() ([]string, error)
 
 	configMu       sync.RWMutex
 	allowedOrigin  string
@@ -55,12 +56,13 @@ type Server struct {
 
 func NewServer(cfg serverConfig, logger *log.Logger) *Server {
 	s := &Server{
-		mux:            http.NewServeMux(),
-		logger:         logger,
+		mux:             http.NewServeMux(),
+		logger:          logger,
 		speechGenerator: vpeak.GenerateSpeech,
-		allowedOrigin:  cfg.allowedOrigin,
-		corsPolicyMode: cfg.corsPolicyMode,
-		userDictPath:   cfg.userDictPath,
+		narratorLister:  vpeak.ListNarrators,
+		allowedOrigin:   cfg.allowedOrigin,
+		corsPolicyMode:  cfg.corsPolicyMode,
+		userDictPath:    cfg.userDictPath,
 	}
 
 	s.registerRoutes()
@@ -73,6 +75,7 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("/", s.handleRoot)
+	s.mux.HandleFunc("/speakers", s.enableCORS(s.handleSpeakers))
 	s.mux.HandleFunc("/audio_query", s.enableCORS(s.handleAudioQuery))
 	s.mux.HandleFunc("/synthesis", s.enableCORS(s.handleSynthesis))
 	s.mux.HandleFunc("/user_dict", s.enableCORS(s.handleUserDict))
@@ -112,14 +115,41 @@ func validateOptionalRange(value *int, min, max int) error {
 	return nil
 }
 
+// validateEmotionOption checks an emotion expression syntactically and returns
+// the trimmed value. Any emotion name is accepted so that narrator-specific
+// emotions (character products, add-on narrators) work; whether a name is
+// actually supported is left to VOICEPEAK. Weights must be integers in 0-100.
 func validateEmotionOption(raw string) (string, error) {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return "", nil
 	}
 
-	if _, err := vpeak.ParseEmotion(raw); err != nil {
-		return "", err
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return "", fmt.Errorf("empty emotion segment")
+		}
+
+		name, value, hasValue := strings.Cut(part, "=")
+		name = strings.TrimSpace(name)
+		if name == "" {
+			return "", fmt.Errorf("empty emotion name")
+		}
+		if !hasValue {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return "", fmt.Errorf("empty emotion value for %s", name)
+		}
+		weight, err := strconv.Atoi(value)
+		if err != nil {
+			return "", fmt.Errorf("invalid emotion weight for %s: %w", name, err)
+		}
+		if weight < 0 || weight > 100 {
+			return "", fmt.Errorf("emotion weight for %s must be between 0 and 100", name)
+		}
 	}
 
 	return raw, nil
@@ -181,6 +211,27 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	if err := tmpl.Execute(w, data); err != nil {
 		http.Error(w, fmt.Sprintf("Failed to render template: %v", err), http.StatusInternalServerError)
 	}
+}
+
+// handleSpeakers returns the narrator names installed in the local VOICEPEAK.
+// The list is queried live so newly installed character products and add-on
+// narrators show up without any code change.
+func (s *Server) handleSpeakers(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Only GET method is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	speakers, err := s.narratorLister()
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to list speakers: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if speakers == nil {
+		speakers = []string{}
+	}
+
+	writeJSON(w, http.StatusOK, speakers)
 }
 
 func (s *Server) handleAudioQuery(w http.ResponseWriter, r *http.Request) {

--- a/server_test.go
+++ b/server_test.go
@@ -33,10 +33,13 @@ func TestValidateEmotionOption(t *testing.T) {
 		{name: "single weighted", input: "happy=50", want: "happy=50"},
 		{name: "multi weighted", input: "happy=40,fun=60", want: "happy=40,fun=60"},
 		{name: "trim spaces", input: " happy=40,fun=60 ", want: "happy=40,fun=60"},
-		{name: "invalid name", input: "joy=50", wantErr: true},
+		{name: "dynamic name", input: "joy=50", want: "joy=50"},
+		{name: "dynamic bare name", input: "amaama", want: "amaama"},
 		{name: "invalid integer", input: "happy=foo", wantErr: true},
 		{name: "too high", input: "happy=101", wantErr: true},
 		{name: "negative", input: "happy=-1", wantErr: true},
+		{name: "empty value", input: "happy=", wantErr: true},
+		{name: "empty segment", input: "happy=50,,fun=50", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -74,7 +77,7 @@ func TestAudioQueryEmotionValidation(t *testing.T) {
 		{name: "single name", emotion: "happy", wantStatus: http.StatusOK, wantBody: "happy"},
 		{name: "single weighted", emotion: "happy=50", wantStatus: http.StatusOK, wantBody: "happy=50"},
 		{name: "multi weighted", emotion: "happy=40,fun=60", wantStatus: http.StatusOK, wantBody: "happy=40,fun=60"},
-		{name: "invalid name", emotion: "joy=50", wantStatus: http.StatusBadRequest},
+		{name: "dynamic name", emotion: "joy=50", wantStatus: http.StatusOK, wantBody: "joy=50"},
 		{name: "invalid integer", emotion: "happy=foo", wantStatus: http.StatusBadRequest},
 		{name: "too high", emotion: "happy=101", wantStatus: http.StatusBadRequest},
 	}
@@ -152,10 +155,11 @@ func TestSynthesisEmotionValidation(t *testing.T) {
 			wantGenerator: true,
 		},
 		{
-			name:            "invalid name",
-			body:            `{"text":"hello","speaker":"f1","emotion":"joy=50"}`,
-			wantStatus:      http.StatusBadRequest,
-			wantErrorSubstr: "Invalid emotion",
+			name:          "dynamic name",
+			body:          `{"text":"hello","speaker":"f1","emotion":"joy=50"}`,
+			wantStatus:    http.StatusOK,
+			wantEmotion:   "joy=50",
+			wantGenerator: true,
 		},
 		{
 			name:            "invalid integer",
@@ -241,4 +245,67 @@ func TestSynthesisEmotionValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleSpeakers(t *testing.T) {
+	t.Run("returns installed narrators", func(t *testing.T) {
+		server := newBaseTestServer()
+		server.narratorLister = func() ([]string, error) {
+			return []string{"Japanese Female 1", "Zundamon"}, nil
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/speakers", nil)
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		if got := rec.Header().Get("Content-Type"); got != "application/json" {
+			t.Fatalf("expected application/json, got %q", got)
+		}
+
+		var got []string
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			t.Fatalf("failed to decode response: %v", err)
+		}
+		want := []string{"Japanese Female 1", "Zundamon"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
+
+	t.Run("lister error returns 500", func(t *testing.T) {
+		server := newBaseTestServer()
+		server.narratorLister = func() ([]string, error) {
+			return nil, errors.New("voicepeak not found")
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/speakers", nil)
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("expected 500, got %d", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "Failed to list speakers") {
+			t.Fatalf("unexpected body: %q", rec.Body.String())
+		}
+	})
+
+	t.Run("method not allowed", func(t *testing.T) {
+		server := newBaseTestServer()
+		req := httptest.NewRequest(http.MethodPost, "/speakers", nil)
+		rec := httptest.NewRecorder()
+		server.Handler().ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("expected 405, got %d", rec.Code)
+		}
+	})
 }


### PR DESCRIPTION
## Overview

Updates vpeakserver to vpeak `v0.3.0` and exposes its dynamic narrator/emotion support. Any narrator installed in the local VOICEPEAK (character products, add-on narrators) can now be used, and emotion names are no longer limited to the built-in four.

## Changes

- **Bump `github.com/shinshin86/vpeak` v0.2.0 → v0.3.0.**
- **Add `GET /speakers`** — returns the narrator names installed in the local VOICEPEAK as a JSON array (e.g. `["Japanese Female 1", "Zundamon"]`). The list is queried live via `vpeak.ListNarrators()`, so newly installed narrators appear without code changes. The lister is injected on `Server` so it can be stubbed in tests.
- **Relax emotion validation** — `validateEmotionOption` now validates syntax only (any emotion name, comma-separated, integer weights in `0–100`) instead of restricting to `happy`/`fun`/`angry`/`sad`. This lets narrator-specific emotions through while still rejecting malformed input early; whether an emotion name is actually supported is left to VOICEPEAK. Validating syntax up front also keeps the server from being taken down by vpeak's `log.Fatalf` on malformed values.
- **Docs** — document `/speakers` and the dynamic narrator/emotion behavior in the README.

## Compatibility

No breaking changes for existing clients:
- The `speaker` parameter still accepts the short aliases (`f1`–`m3`, `c`) as well as full narrator names.
- `happy` / `fun` / `angry` / `sad` and `0–100` weights behave as before.
- The only behavioral change is that an unknown emotion *name* (e.g. `joy=50`) is no longer rejected with `400` at `/audio_query`; it is forwarded to VOICEPEAK, which decides whether it is valid.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt`, `go test ./...` all pass (added a `/speakers` handler test and dynamic-emotion test cases).
- Manually verified against a running server with VOICEPEAK installed:
  - `GET /speakers` returns the installed narrators; `POST /speakers` returns `405`.
  - `/audio_query` accepts dynamic emotion names and still rejects malformed weights with `400`.
  - `/synthesis` generates audio for both short aliases and full narrator names; bare emotion names normalize to `=100` and zero-weighted emotions fall back to natural (confirmed by identical output hashes).
  - An unsupported emotion name returns `500` with a helpful hint, and the server stays up.
